### PR TITLE
Update release notes with decimal separator detection

### DIFF
--- a/_posts/2026-08-07-release.md
+++ b/_posts/2026-08-07-release.md
@@ -16,6 +16,9 @@ Error entries in the Monitor tab now show when they occurred and a breadcrumb of
 
 The automation settings panel is now organized into a clear accordion with step-by-step progress indicators. Manually refreshing an automation suspended after a trial ends now shows a clear "Refresh Manually" label with guidance on what it does.
 
+#### Decimal Separator Detection –
+Mammoth no longer misreads a comma used as a decimal separator as a thousands separator, so imported values are no longer inflated by orders of magnitude. The detected number format now appears on the column profile.
+
 ### Defect Fixes :
 
 Resolved the following issues:


### PR DESCRIPTION
Added a section on decimal separator detection, clarifying that Mammoth now correctly interprets commas as decimal separators, preventing inflated imported values.